### PR TITLE
Fixed error when creating image due to zoom level.

### DIFF
--- a/jquery.flot.saveAsImage.js
+++ b/jquery.flot.saveAsImage.js
@@ -163,7 +163,7 @@ Customizations:
         init: init,
         options: options,
         name: 'saveAsImage',
-        version: '1.5'
+        version: '1.6'
     });
 
 })(jQuery, Canvas2Image);

--- a/jquery.flot.saveAsImage.js
+++ b/jquery.flot.saveAsImage.js
@@ -85,6 +85,12 @@ Customizations:
         if (!!theClasses) {
             theMergedCanvas = new theClasses.Canvas("mergedCanvas", plot.getPlaceholder());
             var mergedContext = theMergedCanvas.context;
+            var plotCanvas = plot.getCanvas();
+            
+            theMergedCanvas.element.height = plotCanvas.height;
+            theMergedCanvas.element.width = plotCanvas.width;
+            
+            mergedContext.restore();
 
             $(theMergedCanvas).css({
                 "visibility": "hidden",
@@ -92,7 +98,7 @@ Customizations:
                 "position": "absolute"
             });
 
-            var $canvases = $(plot.getPlaceholder()).find("canvas");
+            var $canvases = $(plot.getPlaceholder()).find("canvas").not('.mergedCanvas');
             $canvases.each(function(index, canvas) {
                 mergedContext.drawImage(canvas, 0, 0);
             });


### PR DESCRIPTION
When the Canvas object is created, it has its scaling changed by the code which handles pixel density within flot. When drawing the canvases onto the merged canvas, this scaling would inflate the picture, and cause it to be cropped. mergedContext.restore() within mergeCanvases fixes this issue.

A second issue occurs when the zoom level changes between creating the plot, and creating the image. The height and width parameters will be different between the canvases, so adjusting the merged canvas height and width within mergeCanvases fixes this.

The third issue stems from the .find('canvas') within mergeCanvases, as this would also find theMergedCanvas within the placeholder. Using the .not('.mergedCanvas') fixes this.
